### PR TITLE
Update to Support Color Objects in SASS

### DIFF
--- a/_vary.scss
+++ b/_vary.scss
@@ -136,7 +136,6 @@ $vary-loop-map: $vary-map;
 
   @return $ret;
 }
-q
 
 
 /// Filters the entities provieded into a final list

--- a/_vary.scss
+++ b/_vary.scss
@@ -134,9 +134,9 @@ $vary-loop-map: $vary-map;
     @error 'The entity `#{$entity}` doesn\'t have a value for `#{$key}`.';    
   }
 
-  @return unquote($ret);
+  @return $ret;
 }
-
+q
 
 
 /// Filters the entities provieded into a final list


### PR DESCRIPTION
Currently if you passed in a color to a sass-vary map and then pulled it out using _vary-get_(**_key name**__)_ and tried to apply functions like lighten and darken it would throw an error because the value pulled out of the map had the type-of "String" and not "Color" which is the required input for lighten and darken functions in SASS, the change in quoting mitigates this issue.
