### PR TITLE
Remove wrong output from targeting example

### DIFF
--- a/demos.html
+++ b/demos.html
@@ -376,11 +376,6 @@ html.js .is-superadmin .foo{
 	background: pink;
 	border: 10px solid red;
 }
-
-.is-superadmin .foo .example{
-	background: black;
-	border: .1em dashed red;
-}
 </pre>
 					</div>
 				</div>


### PR DESCRIPTION
I removed the misplaced output which didn't match the input, so now it matches the correct one (and the sassmeister example).